### PR TITLE
remove scripts, implement correctly cairosvg

### DIFF
--- a/data.json
+++ b/data.json
@@ -2,7 +2,7 @@
     "facebook": {
         "android": [
             "com_facebook_katana",
-            "com_danvelazco_fbwrapper" 
+            "com_danvelazco_fbwrapper"
         ],
         "linux": {
             "root": "web-facebook",

--- a/gen.py
+++ b/gen.py
@@ -74,20 +74,6 @@ def convert_svg2png(infile, outfile, w, h):
         img.finish()
 
 
-class cd:
-
-    def __init__(self, newPath):
-        """Context manager for changing the current working directory"""
-        self.newPath = path.expanduser(newPath)
-
-    def __enter__(self):
-        self.savedPath = getcwd()
-        chdir(self.newPath)
-
-    def __exit__(self, etype, value, traceback):
-        chdir(self.savedPath)
-
-
 sizes = listdir("icons")
 adir = "com.numix.icons_circle/MainActivity22/app/src/main/res/drawable-xxhdpi/"
 ldir = "numix-icon-theme-circle/Numix-Circle/"
@@ -111,9 +97,12 @@ elif ans == "linux":
             root = icons[icon]["linux"]["root"] + ".svg"
             copy2("icons/" + size + "/" + icon + ".svg",
                   ldir + size + "/apps/" + root)
-        with cd(ldir + size + "/apps/"):
-            for link in icons[icon]["linux"]["symlinks"]:
-                symlink(root, link + ".svg")
+            if icons[icon]["linux"]["symlinks"]:
+                for link in icons[icon]["linux"]["symlinks"]:
+                    try:
+                        symlink(root, ldir + size + "/apps/" + link + ".svg")
+                    except FileExistsError:
+                        continue
 elif ans == "osx":
     print("\nGenerating OSX theme...")
     for ext in ["icns", "pngs", "vectors"]:

--- a/gen.py
+++ b/gen.py
@@ -11,13 +11,16 @@
 from json import load
 from os import chdir, devnull, getcwd, listdir, makedirs, path, symlink
 from shutil import copy2
-from subprocess import call
+from subprocess import call, PIPE, Popen
 try:
-    # Use of CairoSVG rather than the Inkscape bashscripts
-    # hasn't been implemented yet but will be before release
     from cairosvg import svg2png
-except ImportError:
-    exit("You need python3-cairosvg to run this scripts")
+    use_inkscape = False
+except (ImportError, AttributeError):
+    ink_flag = call(['which', 'inkscape'], stdout=PIPE, stderr=PIPE)
+    if ink_flag == 0:
+        use_inkscape = True
+    else:
+        exit("Can't load cariosvg nor inkscape")
 
 # Importing CSV
 with open('data.json') as data:
@@ -36,6 +39,25 @@ while True:
 def mkdir(dir):
     if not path.exists(dir):
         makedirs(dir)
+
+
+def convert_svg2png(infile, outfile, width, height):
+    """
+        Converts svg files to png using Cairosvg or Inkscape
+        @file_path : String; the svg file absolute path
+        @dest_path : String; the png file absolute path
+    """
+    if use_inkscape:
+        p = Popen(["inkscape", "-f", infile, "-e", outfile,
+                   "-w" + str(width), "-h" + str(height)],
+                  stdout=PIPE, stderr=PIPE)
+        output, err = p.communicate()
+    else:
+        with open(infile, "r") as content_file:
+            svg = content_file.read()
+        fout = open(outfile, "wb")
+        svg2png(bytestring=bytes(svg, "UTF-8"), write_to=fout)
+        fout.close()
 
 
 class cd:
@@ -62,39 +84,40 @@ if ans == "android":
     mkdir(adir)
     for icon in icons:
         for name in icons[icon]["android"]:
-            copy2("icons/48/"+icon+".svg", adir+name+".svg")
-    # Androidizing
-    copy2("scripts/android.sh", adir)
-    with cd(adir):
-        devnull = open(devnull, 'w')
-        call("./android.sh", stdout=devnull, stderr=devnull)
+            name = name.replace("_", ".")
+            convert_svg2png("icons/48/" + icon + ".svg",
+                            adir + name + ".png", 192, 192)
 elif ans == "linux":
     print("\nGenerating Linux theme...")
     for size in sizes:
         mkdir(ldir + size + "/apps")
     for icon in icons:
         for size in sizes:
-            root = icons[icon]["linux"]["root"]+".svg"
-            copy2("icons/"+size+"/"+icon+".svg", ldir+size+"/apps/"+root)
-            with cd(ldir+size+"/apps/"):
-                for link in icons[icon]["linux"]["symlinks"]:
-                    symlink(root, link+".svg")
+            root = icons[icon]["linux"]["root"] + ".svg"
+            copy2("icons/" + size + "/" + icon + ".svg",
+                  ldir + size + "/apps/" + root)
+        with cd(ldir + size + "/apps/"):
+            for link in icons[icon]["linux"]["symlinks"]:
+                symlink(root, link + ".svg")
 elif ans == "osx":
     print("\nGenerating OSX theme...")
     for ext in ["icns", "pngs", "vectors"]:
         mkdir(odir + ext)
+    try:
+        ink_flag = call(['which', 'png2icns'], stdout=PIPE, stderr=PIPE)
+        if ink_flag != 0:
+            raise Exception
+    except (FileNotFoundError, Exception):
+        exit("You will need png2icns in order to generate OSX theme")
     for icon in icons:
         for name in icons[icon]["osx"]:
-            copy2("icons/48/"+icon+".svg", odir+"vectors/"+name+".svg")
-            copy2("icons/48/"+icon+".svg", odir+"pngs/"+name+".svg")
-    copy2("scripts/osx.sh", odir+"pngs/")
-    with cd(odir + "pngs"):
-        devnull = open(devnull, 'r')
-        call("./osx.sh", stdout=devnull, stderr=devnull)
-    for icon in listdir(odir+"pngs"):
-        call(["png2icns", odir+"icns/"+icon.replace(".png", ".icn"),
-              odir+"pngs/"+icon], stdout=devnull, stderr=devnull)
-
+            copy2("icons/48/" + icon + ".svg",
+                  odir + "vectors/" + name + ".svg")
+            convert_svg2png("icons/48/" + icon + ".svg",
+                            odir + "pngs/" + name + ".png", 1024, 1024)
+            call(["png2icns", odir + "icns/" + name + ".icn",
+                 odir + "pngs/" + name + ".png"],
+                 stdout=PIPE, stderr=PIPE)
 # Clean Up
 print("Done!\n")
 exit(0)

--- a/gen.py
+++ b/gen.py
@@ -9,7 +9,7 @@
 
 # Sorting out modules
 from json import load
-from os import chdir, devnull, getcwd, listdir, makedirs, path, remove, symlink
+from os import chdir, devnull, getcwd, listdir, makedirs, path, symlink
 from shutil import copy2
 from subprocess import PIPE, Popen, call
 from io import BytesIO

--- a/gen.py
+++ b/gen.py
@@ -25,7 +25,6 @@ except (ImportError, AttributeError):
         use_inkscape = True
     else:
         exit("Can't load cariosvg nor inkscape")
-use_inkscape = False
 # Importing CSV
 with open('data.json') as data:
     icons = load(data)

--- a/scripts/android.sh
+++ b/scripts/android.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-for f in *.*; do mv "$f" "${f//./_}"; done
-for f in *_svg*; do mv "$f" "${f//_svg/.svg}"; done
-for f in *_sh*; do mv "$f" "${f//_sh/.sh}"; done
-for f in `find`; do mv -v $f `echo $f | tr '[A-Z]' '[a-z]'`; done
-for f in *.svg; do inkscape $f --without-gui --export-png="${f%.*}.png" --export-background-opacity 0.0 -w 192 -h 192; done
-rm android.sh *.svg

--- a/scripts/osx.sh
+++ b/scripts/osx.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-for f in *.svg; do inkscape $f --without-gui --export-png="${f%.*}.png" --export-background-opacity 0.0 -w 1024 -h 1024; done
-rm osx.sh *.svg


### PR DESCRIPTION
Things i've done till now : 
- Remove both scripts
- Use Inkscape if Cairosvg is not installed
- Check if `png2icns` is installed for OSX conversion

Things still not working correctly
- `svg2png` does not convert svg files correctly
- still can't scale svg icons using `svg2png`

I will open an other PR to fix those

To test the script using `inkscape` (everything works fine with it)  add `use_inkscape = True` after the line 24